### PR TITLE
Fix bug printing NULL or (error) on attribute access

### DIFF
--- a/Templates/AXMLTemplate.bt
+++ b/Templates/AXMLTemplate.bt
@@ -217,29 +217,32 @@ string AttributeRead(attribute &i) {
 
     local string uri;
     if(i.uri > 0 && i.uri < 0xFFFFFFFF) {
-        PoolItemReader(strings.stringpool.string_item[i.uri]);
+        uri = PoolItemReader(strings.stringpool.string_item[i.uri-1]);
     }
-    if(Strcmp("", uri) == 0) {
-        uri = "NULL";
+    if(Strcmp("", uri) != 0) {
+        uri = uri + ":";
     }
 
     local string name;
-    if(i.name > 0 && i.name < 0xFFFFFFFF) {
-        PoolItemReader(strings.stringpool.string_item[i.name]);
+    if(i.name < 0xFFFFFFFF) {
+        name = PoolItemReader(strings.stringpool.string_item[i.name]);
     }
-    if(Strcmp("", name) == 0) {
-        name = "NULL";
+    if(Strcmp("", name) != 0) {
+        name = name + " = ";
     }
 
     local string data;
-    if(i.data > 0 && i.data < 0xFFFFFFFF) {
-        data = PoolItemReader(strings.stringpool.string_item[i.data]);
+    if(i.string_data < 0xFFFFFFFF) {
+        data = PoolItemReader(strings.stringpool.string_item[i.string_data]);
+    }
+    else if (i.string_data == 0xFFFFFFFF) {
+        SPrintf(data, "%d", i.data);
     }
     if(Strcmp("", data) == 0) {
         data = "NULL";
     }
     local string s;
-    s = SPrintf(s, "%s : %s : %s", uri, name, data);
+    s = SPrintf(s, "%s%s%s", uri, name, data);
     return s;
 }
 


### PR DESCRIPTION
This PR fixes error printing attribute(`NULL : NULL : NULL`, (error), etc.). Details are as follows:

  * `attribute.uri` references string pool index starts at **1**, not 0.
  * Although `attribute.uri` and `attribute.name` has valid index, string representations are not been assigned to local variables.
  * If `attribute.string_data` is invalid(0xFFFFFFFF), `attribute.data` integer is used for data representation , otherwise `string_data` is used. For example, for expressing minSdkVersion=8 attribute, string_data is `0xFFFFFFFF` and data is `8`.

Sample AndroidManifest.xml files are here: [Link](https://app.box.com/s/jhrqm03hhf1s61qkse0l6lbx6q49yvzc). `*.axml` file is AndroidManifest.xml file in APK package; you can use it for template testing. `.xml` file is unpacked AndroidManifest.xml file using [apktool](https://code.google.com/p/android-apktool/).

Additionally I modified printing format; `[uri:]name = data`. If you think previous format is better, tell me and I will revert it.

English is not my mother tongue; please excuse any errors on my part. Thank you for reading this PR!