### PR TITLE
Fixing data descriptor read without flag set

### DIFF
--- a/Templates/ZIPTemplateAdv.bt
+++ b/Templates/ZIPTemplateAdv.bt
@@ -693,8 +693,9 @@ while( !FEof() )
                 Printf("Pointing at %d\n", FTell());
             }
         }
-
-        if(!isJar && record.frCompressedSize == 0 && record.frUncompressedSize == 0)
+        
+        // Only read the data descriptor if bit 3 of the flags is set. Otherwise there is no data descriptor present!
+        if(!isJar && (record.frFlags & FLAG_DescriptorUsedMask) && record.frCompressedSize == 0 && record.frUncompressedSize == 0)
         {
             Printf("Doesn't appear to jar, but going to attempt to parse as one; skipping to dataDescription\n");
             // Skip data if need be, since a JAR doesn't properly set the


### PR DESCRIPTION
Hi!
I was working on the files mentioned in http://vrt-blog.snort.org/2013/08/bytecode-covering-android.html

For two files the template was not working correctly: D816596A70A7117346A2DFB6F8850E39  and 04EEF623255A7CEBD943435ACF237456. For the first file a fix was easy. In the template, a data descriptor would be read even if there is no flag indicating it.

For the later file a fix is more difficult. The file has in the central directory a extra_field_length of 0x8000, which is read by parts of the android system as negative integer. If you jump 0x8000 bytes forward you will find the next central directory. But unfortunately the template tries to parse the extra field and crashes when the header seems to be 0x00. Maybe it would be good to at least skip the extra field parsing in that case completely and just jump to the next directory entry?