### PR TITLE
adding extra check for NO_HEADER extra field

### DIFF
--- a/Templates/ZIPTemplateAdv.bt
+++ b/Templates/ZIPTemplateAdv.bt
@@ -513,10 +513,18 @@ typedef struct {
 	if( deFileNameLength > 0 )
 		char     deFileName[ deFileNameLength ];
 	local int len = deExtraFieldLength;
+
 	while (len > 0)
 	{
-		EXTRAFIELD deExtraField;
-		len -= deExtraField.efDataSize + 4;
+	    EXTRAFIELD deExtraField;
+        if(deExtraField.efHeaderID != EH_NO_HEADER){
+            // If there was a proper header, skip 4 Bytes (Header+Size) plus the data
+	        len -= deExtraField.efDataSize + 4;
+        }
+        else{
+            // If the efHeaderID is a NO_HEADER, there is no size and no data
+            len -= 2;
+        }
 	}
 	if( deFileCommentLength > 0 )
 		uchar    deFileComment[ deFileCommentLength ];


### PR DESCRIPTION
Hi!
The template would crash on EF_NO_HEADER fields, because efDataSize was not defined. also a NO_HEADER field only has 2bytes of length (not 4), so the template would jump to weird places.
i fixed that by adding a extra check!