### PR TITLE
Short Data Descriptors

### DIFF
--- a/Templates/ZIPTemplateAdv.bt
+++ b/Templates/ZIPTemplateAdv.bt
@@ -678,7 +678,7 @@ while( !FEof() )
         }
 
         // JAR's should all have this extra field on the first entry
-        if(record.frExtraFieldLength > 0 && isJar != 1)
+        if(record.frExtraFieldLength > 2 && isJar != 1)
             if(record.frExtraField.efHeaderID == EH_CAFE)
                 isJar = 1;
         if(isJar && record.frCompressedSize == 0 && record.frUncompressedSize == 0)
@@ -693,8 +693,9 @@ while( !FEof() )
                 Printf("Pointing at %d\n", FTell());
             }
         }
-
-        if(!isJar && record.frCompressedSize == 0 && record.frUncompressedSize == 0)
+        
+        // Only read the data descriptor if bit 3 of the flags is set. Otherwise there is no data descriptor present!
+        if(!isJar && ((record.frFlags >> 4) & 1) && record.frCompressedSize == 0 && record.frUncompressedSize == 0)
         {
             Printf("Doesn't appear to jar, but going to attempt to parse as one; skipping to dataDescription\n");
             // Skip data if need be, since a JAR doesn't properly set the

--- a/Templates/ZIPTemplateAdv.bt
+++ b/Templates/ZIPTemplateAdv.bt
@@ -678,7 +678,7 @@ while( !FEof() )
         }
 
         // JAR's should all have this extra field on the first entry
-        if(record.frExtraFieldLength > 2 && isJar != 1)
+        if(record.frExtraFieldLength > 0 && isJar != 1)
             if(record.frExtraField.efHeaderID == EH_CAFE)
                 isJar = 1;
         if(isJar && record.frCompressedSize == 0 && record.frUncompressedSize == 0)

--- a/Templates/ZIPTemplateAdv.bt
+++ b/Templates/ZIPTemplateAdv.bt
@@ -667,7 +667,6 @@ void SeekToDataDescription()
         ZIPDATADESCR dataDescr;
     }
     else{
-        Printf("Found a short header...\n");
         FSeek(start+skip-1-12);
         ZIPDATADESCRSH dataDescr;
     }

--- a/Templates/ZIPTemplateAdv.bt
+++ b/Templates/ZIPTemplateAdv.bt
@@ -513,10 +513,19 @@ typedef struct {
 	if( deFileNameLength > 0 )
 		char     deFileName[ deFileNameLength ];
 	local int len = deExtraFieldLength;
+
 	while (len > 0)
 	{
-		EXTRAFIELD deExtraField;
-		len -= deExtraField.efDataSize + 4;
+        Printf("at --> %d\n", FTell());
+	    EXTRAFIELD deExtraField;
+        if(deExtraField.efHeaderID != EH_NO_HEADER){
+            // If there was a proper header, skip 4 Bytes (Header+Size) plus the data
+	        len -= deExtraField.efDataSize + 4;
+        }
+        else{
+            // If the efHeaderID is a NO_HEADER, there is no size and no data
+            len -= 2;
+        }
 	}
 	if( deFileCommentLength > 0 )
 		uchar    deFileComment[ deFileCommentLength ];

--- a/Templates/ZIPTemplateAdv.bt
+++ b/Templates/ZIPTemplateAdv.bt
@@ -695,7 +695,7 @@ while( !FEof() )
         }
         
         // Only read the data descriptor if bit 3 of the flags is set. Otherwise there is no data descriptor present!
-        if(!isJar && ((record.frFlags >> 4) & 1) && record.frCompressedSize == 0 && record.frUncompressedSize == 0)
+        if(!isJar && (record.frFlags & FLAG_DescriptorUsedMask) && record.frCompressedSize == 0 && record.frUncompressedSize == 0)
         {
             Printf("Doesn't appear to jar, but going to attempt to parse as one; skipping to dataDescription\n");
             // Skip data if need be, since a JAR doesn't properly set the

--- a/Templates/ZIPTemplateAdv.bt
+++ b/Templates/ZIPTemplateAdv.bt
@@ -516,7 +516,6 @@ typedef struct {
 
 	while (len > 0)
 	{
-        Printf("at --> %d\n", FTell());
 	    EXTRAFIELD deExtraField;
         if(deExtraField.efHeaderID != EH_NO_HEADER){
             // If there was a proper header, skip 4 Bytes (Header+Size) plus the data
@@ -546,6 +545,12 @@ typedef struct {
 	uint ddCompressedSize;
 	uint ddUncompressedSize;
 } ZIPDATADESCR;
+// Defines the Data descriptor, short variant without signature
+typedef struct {
+	uint ddCRC <format=hex>;
+	uint ddCompressedSize;
+	uint ddUncompressedSize;
+} ZIPDATADESCRSH;
 
 // Zip64 end of central directory record
 typedef struct {
@@ -648,14 +653,25 @@ void SeekToDataDescription()
 {
     local uint skip = 0;
     local uint start = FTell();
-    while(ReadUInt(FTell()) != S_ZIPDATADESCR)
+    // Need to read until a new Local header / central dir shows up. Then go back 16 bytes and check if there is a data descriptor header or not.
+    // If there is none, use the 12 byte long header.
+    while(ReadUInt(FTell()) != S_ZIPFILERECORD &&ReadUInt(FTell()) != S_ZIPDIRENTRY)
     {
         FSeek(start+skip);
         skip += 1;
     }
     // Fix position
-    FSeek(start+skip-1);
-    ZIPDATADESCR dataDescr;
+    FSeek(start+skip-1-16);
+    if (ReadUInt(FTell()) == S_ZIPDATADESCR){
+        FSeek(start+skip-1-16);
+        ZIPDATADESCR dataDescr;
+    }
+    else{
+        Printf("Found a short header...\n");
+        FSeek(start+skip-1-12);
+        ZIPDATADESCRSH dataDescr;
+    }
+        
 }
 
 //--------------------------------------------


### PR DESCRIPTION
Hi!
As I found out, it is possible that data descriptors do not have a signature. See https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT 

> 4.3.9.3 Although not originally assigned a signature, the value 
> 0x08074b50 has commonly been adopted as a signature value 
> for the data descriptor record.  Implementers should be 
> aware that ZIP files may be encountered with or without this 
> signature marking data descriptors and SHOULD account for
> either case when reading ZIP files to ensure compatibility.

I added an extra check for that and the template works now with files that have this signature not set.
